### PR TITLE
Simply errors

### DIFF
--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -197,7 +197,7 @@ defmodule Kconnectex.CLI do
         choices = Enum.map(connectors, fn c -> "  * #{c}" end) |> Enum.join("\n")
 
         message = """
-        There are #{length(connectors)} present. Please provide one of:
+        There are #{length(connectors)} connectors present. Please provide one of:
         #{choices}
         """
 

--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -24,6 +24,7 @@ defmodule Kconnectex.CLI do
       ["loggers" | _] -> help(:loggers)
       ["logger" | _] -> help(:loggers)
       ["plugins" | _] -> help(:plugins)
+      ["plugin" | _] -> help(:plugins)
       ["tasks" | _] -> help(:tasks)
       ["task" | _] -> help(:tasks)
       ["connectors" | _] -> help(:connectors)
@@ -124,7 +125,7 @@ defmodule Kconnectex.CLI do
     |> display()
   end
 
-  defp run(%{command: ["plugins", "validate"], url: url}) do
+  defp run(%{command: ["plugin", "validate"], url: url}) do
     case read_stdin() do
       {:ok, json} ->
         client(url)

--- a/lib/kconnectex/cli/help.ex
+++ b/lib/kconnectex/cli/help.ex
@@ -20,6 +20,7 @@ defmodule Kconnectex.CLI.Help do
       loggers
       logger
       plugins
+      plugin
       tasks
       task
     """)
@@ -76,7 +77,7 @@ defmodule Kconnectex.CLI.Help do
     plugins
       List plugins installed on Connect worker
 
-    plugins validate
+    plugin validate
       Validate connector plugin configuration.
       ConfigFile is read from STDIN and assumed to be JSON.
     """)

--- a/lib/kconnectex/cli/help.ex
+++ b/lib/kconnectex/cli/help.ex
@@ -77,9 +77,12 @@ defmodule Kconnectex.CLI.Help do
     plugins
       List plugins installed on Connect worker
 
-    plugin validate
+    plugin validate [--errors-only]
       Validate connector plugin configuration.
       ConfigFile is read from STDIN and assumed to be JSON.
+
+      --errors-only
+      Filters the configuration to only those with errors.
     """)
   end
 

--- a/test/kconnectex/cli/options_test.exs
+++ b/test/kconnectex/cli/options_test.exs
@@ -49,6 +49,16 @@ defmodule Kconnectex.CLI.OptionsTest do
       assert opts.command == ["cluster", "info"]
       assert opts.errors == []
     end
+
+    test "--errors-only only valid with plugin validate" do
+      opts = Options.parse(["--url", "example.com", "plugin", "validate", "--errors-only"])
+
+      assert {:errors_only, true} in opts.options
+
+      opts = Options.parse(["--url", "example.com", "connectors", "--errors-only"])
+
+      assert "Unknown flag: --errors-only" in opts.errors
+    end
   end
 
   describe ".parse/2" do


### PR DESCRIPTION
* `plugins validate` changed to `plugin validate` since it is for a single plugin
* `plugin validate --errors-only` only displays configs with errors (or `[]` with no errors)