### PR TITLE
Format connector status

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -7,7 +7,7 @@ defmodule Helpers.Config do
   Some helper functions for configuring connectors
   """
 
-  def filestream(topic \\ "license-stream", file \\ "/kafka/LICENSE") do
+  def filestream(topic \\ "license-stream", file \\ "/usr/share/doc/kafka/LICENSE") do
     %{
       "connector.class" => "FileStreamSource",
       "topic" => topic,

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :tesla, disable_deprecated_builder_warning: true

--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -234,6 +234,19 @@ defmodule Kconnectex.CLI do
     |> display()
   end
 
+  defp run(%{command: ["connector", "status", connector], url: url}) do
+    case Kconnectex.Connectors.status(client(url), connector) do
+      {:ok, status} ->
+        # TODO: add --json option
+        status
+        |> Kconnectex.CLI.Commands.Connectors.render()
+        |> IO.puts()
+
+      otherwise ->
+        display(otherwise)
+    end
+  end
+
   defp run(%{command: ["connector", subcommand, connector], url: url})
        when subcommand in ~w(config delete info pause resume status) do
     apply(Kconnectex.Connectors, String.to_atom(subcommand), [client(url), connector])

--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -95,9 +95,19 @@ defmodule Kconnectex.CLI do
     end
   end
 
-  defp run(%{command: ["cluster"], url: url}) do
+  defp run(%{command: ["cluster"]} = opts) do
+    run(Map.put(opts, :command, ["cluster", "info"]))
+  end
+
+  defp run(%{command: ["cluster", "info"], url: url}) do
     client(url)
     |> Kconnectex.Cluster.info()
+    |> display()
+  end
+
+  defp run(%{command: ["cluster", "health"], url: url}) do
+    client(url)
+    |> Kconnectex.Cluster.health()
     |> display()
   end
 

--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -234,10 +234,9 @@ defmodule Kconnectex.CLI do
     |> display()
   end
 
-  defp run(%{command: ["connector", "status", connector], url: url}) do
+  defp run(%{command: ["connector", "status", connector], url: url, format: :text}) do
     case Kconnectex.Connectors.status(client(url), connector) do
       {:ok, status} ->
-        # TODO: add --json option
         status
         |> Kconnectex.CLI.Commands.Connectors.render()
         |> IO.puts()

--- a/lib/kconnectex/cli/commands/connectors.ex
+++ b/lib/kconnectex/cli/commands/connectors.ex
@@ -1,0 +1,31 @@
+defmodule Kconnectex.CLI.Commands.Connectors do
+  def render(status) do
+    tasks =
+      Enum.flat_map(status["tasks"], fn task ->
+        state = "Task #{task["id"]}: #{task["state"]}"
+
+        if Map.has_key?(task, "trace") do
+          formatted = String.split(task["trace"], "\n", trim: true)
+          trace = ["Trace:", join(formatted)]
+
+          [state | trace]
+        else
+          [state]
+        end
+      end)
+
+    join([
+      status["name"],
+      String.duplicate("-", String.length(status["name"])),
+      "Connector: " <> status["connector"]["state"]
+      | tasks
+    ])
+  end
+
+  defp join(list, sep \\ "\n") do
+    binary =
+      list |> Enum.intersperse(sep) |> :erlang.iolist_to_binary()
+
+    binary <> sep
+  end
+end

--- a/lib/kconnectex/cli/help.ex
+++ b/lib/kconnectex/cli/help.ex
@@ -30,7 +30,7 @@ defmodule Kconnectex.CLI.Help do
     IO.puts("""
     #{help_header()}
 
-    cluster
+    info
       Display information about Kafka Connect cluster
     """)
   end

--- a/lib/kconnectex/cli/help.ex
+++ b/lib/kconnectex/cli/help.ex
@@ -32,6 +32,9 @@ defmodule Kconnectex.CLI.Help do
 
     info
       Display information about Kafka Connect cluster
+
+    health
+      Display the health of the Kafka Connect cluster
     """)
   end
 

--- a/lib/kconnectex/cli/options.ex
+++ b/lib/kconnectex/cli/options.ex
@@ -2,7 +2,7 @@ defmodule Kconnectex.CLI.Options do
   alias Kconnectex.CLI.ConfigFile
 
   @enforce_keys [:config]
-  defstruct [:config, url: :unset, help?: false, command: [], options: [], errors: []]
+  defstruct [:config, url: :unset, help?: false, format: :text, command: [], options: [], errors: []]
 
   def extract(args) do
     case ConfigFile.read() do
@@ -19,7 +19,7 @@ defmodule Kconnectex.CLI.Options do
   end
 
   def parse(args, config \\ %{}) do
-    global_flags = [cluster: :string, help: :boolean, url: :string]
+    global_flags = [cluster: :string, help: :boolean, url: :string, json: :boolean]
     command_flags = [
       # connectors
       expand: :string,
@@ -34,6 +34,7 @@ defmodule Kconnectex.CLI.Options do
 
     %__MODULE__{
       help?: Keyword.get(parsed, :help, false),
+      format: (if Keyword.get(parsed, :json, false), do: :json, else: :text),
       config: config
     }
     |> with_command(command, extract_flags(parsed, command_flags))

--- a/lib/kconnectex/connector_plugins.ex
+++ b/lib/kconnectex/connector_plugins.ex
@@ -46,7 +46,7 @@ defmodule Kconnectex.ConnectorPlugins do
 
       > config = %{
           "connector.class" => "org.apache.kafka.connect.file.FileStreamSinkConnector",
-          "file" => "/kafka/LICENSE",
+          "file" => "/usr/share/doc/kafka/LICENSE",
           "topics" => "license-stream",
           "name" => "license-stream"
         }

--- a/lib/kconnectex/tasks.ex
+++ b/lib/kconnectex/tasks.ex
@@ -24,7 +24,7 @@ defmodule Kconnectex.Tasks do
          %{
            "config" => %{
              "batch.size" => "2000",
-             "file" => "/kafka/LICENCE",
+             "file" => "/usr/share/doc/kafka/LICENSE",
              "task.class" => "org.apache.kafka.connect.file.FileStreamSourceTask",
              "topic" => "license-lines"
            },

--- a/mix.exs
+++ b/mix.exs
@@ -26,8 +26,8 @@ defmodule Kconnectex.MixProject do
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
 
-      {:tesla, "~> 1.4.0"},
-      {:hackney, "~> 1.16.0"},
+      {:tesla, "~> 1.15.0"},
+      {:hackney, "~> 1.21.0"},
       {:jason, ">= 1.0.0"},
       # https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27
       {:ssl_verify_fun, ">= 0.0.0", manager: :rebar3, override: true}

--- a/test/kconnectex/cli/commands/connectors_test.exs
+++ b/test/kconnectex/cli/commands/connectors_test.exs
@@ -1,0 +1,75 @@
+defmodule Kconnectex.Cli.Commands.ConnectorsTest do
+  use ExUnit.Case, async: true
+
+  alias Kconnectex.CLI.Commands.Connectors
+
+  describe "render/1" do
+    test "shows connector name" do
+      status = %{
+        "name" => "NAME",
+        "connector" => %{"state" => "RUNNING"},
+        "tasks" => []
+      }
+
+      assert Connectors.render(status) == """
+             NAME
+             ----
+             Connector: RUNNING
+             """
+    end
+
+    test "shows tasks" do
+      status = %{
+        "name" => "NAME",
+        "connector" => %{"state" => "RUNNING"},
+        "tasks" => [
+          %{"id" => "0", "state" => "PAUSED"},
+          %{"id" => "1", "state" => "STOPPED"},
+          %{"id" => "2", "state" => "RUNNING"}
+        ]
+      }
+
+      assert Connectors.render(status) == """
+             NAME
+             ----
+             Connector: RUNNING
+             Task 0: PAUSED
+             Task 1: STOPPED
+             Task 2: RUNNING
+             """
+    end
+
+    test "shows task stack traces" do
+      status = %{
+        "name" => "NAME",
+        "connector" => %{"state" => "RUNNING"},
+        "tasks" => [
+          %{"id" => "0", "state" => "PAUSED"},
+          %{
+            "id" => "1",
+            "state" => "ERROR",
+            "trace" =>
+              "com.some.company.package.modules.BadException thrown by\nline 12345...\nline 123456..."
+          },
+          %{"id" => "2", "state" => "RUNNING"}
+        ]
+      }
+
+      assert Connectors.render(status) == """
+             NAME
+             ----
+             Connector: RUNNING
+             Task 0: PAUSED
+             Task 1: ERROR
+             Trace:
+             com.some.company.package.modules.BadException thrown by
+             line 12345...
+             line 123456...
+
+             Task 2: RUNNING
+             """
+    end
+
+    # defp status(name, state, tasks \\ [])
+  end
+end

--- a/test/kconnectex/connector_plugins_test.exs
+++ b/test/kconnectex/connector_plugins_test.exs
@@ -3,7 +3,7 @@ defmodule Kconnectex.ConnectorPluginsTest do
 
   @file_stream_config %{
     "connector.class" => "org.apache.kafka.connect.file.FileStreamSinkConnector",
-    "file" => "/kafka/LICENSE",
+    "file" => "/usr/share/doc/kafka/LICENSE",
     "topics" => "license-stream",
     "name" => "license-stream"
   }

--- a/test/kconnectex/request_test.exs
+++ b/test/kconnectex/request_test.exs
@@ -111,7 +111,7 @@ defmodule Kconnectex.RequestTest do
 
     valid_config = %{
       "connector.class" => "org.apache.kafka.connect.file.FileStreamSinkConnector",
-      "file" => "/kafka/LICENSE",
+      "file" => "/usr/share/doc/kafka/LICENSE",
       "topics" => "license-stream",
       "name" => "license-stream"
     }

--- a/test/kconnectex/tasks_test.exs
+++ b/test/kconnectex/tasks_test.exs
@@ -10,7 +10,7 @@ defmodule Kconnectex.TasksTest do
           "id" => %{"connector" => "filestream", "task" => 0},
           "config" => %{
             "batch.size" => "2000",
-            "file" => "/kafka/LICENSE",
+            "file" => "/usr/share/doc/kafka/LICENSE",
             "task.class" => "org.apache.kafka.connect.file.FileStreamSourceTask",
             "topic" => "license-stream"
           }


### PR DESCRIPTION
Merge in my kc-connector-status script.

I think this format will work better with a future `--watch` option.