### PR TITLE
Validate errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,10 @@ Can be `:info`, `:status`, or both as `[:info, :status]`.
 
 Can be a comma-separated list of values for `:expand` in `Connectors.list/2`.
 
-* (cli) Add `--errors-only` option to `plugin validate`
+* (cli) Add `--json` option to `plugin validate`
 
-This will only configs that have an error present.
+By default, now shows a table of configuration errors. The `--json` flag will
+show the fulll JSON response.
 
 ### Fixed
 

--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -408,16 +408,7 @@ defmodule Kconnectex.CLI do
     end
   end
 
-  defp extract_errors({:ok, result}, opts) do
-    if Keyword.get(opts.options, :errors_only, false) do
-      configs_with_error =
-        Enum.filter(result["configs"], fn config ->
-          Enum.any?(get_in(config, ["value", "errors"]))
-        end)
-
-      {:ok, configs_with_error}
-    else
-      {:ok, result}
-    end
+  defp extract_errors({:ok, result}, _options) do
+    {:ok, result}
   end
 end

--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -135,7 +135,7 @@ defmodule Kconnectex.CLI do
     |> display()
   end
 
-  defp run(%{command: ["plugin", "validate"], options: options, url: url}) do
+  defp run(options = %{command: ["plugin", "validate"], url: url}) do
     case read_stdin() do
       {:ok, json} ->
         client(url)
@@ -317,6 +317,10 @@ defmodule Kconnectex.CLI do
 
   defp display(:ok), do: IO.puts("Success")
 
+  defp display({:text, lines}) do
+    Enum.each(lines, &IO.puts/1)
+  end
+
   defp display({:ok, result}) do
     result
     |> Jason.encode!(pretty: true)
@@ -378,14 +382,40 @@ defmodule Kconnectex.CLI do
 
   defp extract_errors({:error, reason}, _options), do: {:error, reason}
 
-  defp extract_errors({:ok, result}, options) do
-    if Keyword.get(options, :errors_only, false) do
-      errors =
+  defp extract_errors({:ok, result}, %{format: :text}) do
+    configs_with_error =
+      Enum.filter(result["configs"], fn config ->
+        Enum.any?(get_in(config, ["value", "errors"]))
+      end)
+
+    if Enum.any?(configs_with_error) do
+      name_errors = Enum.flat_map(configs_with_error, fn config ->
+        Enum.map(config["value"]["errors"], fn error ->
+          [config["value"]["name"], error]
+        end)
+      end)
+
+      # TODO: Table?
+      table = [["CONFIG", "ERROR"] | name_errors]
+      width = table |> Enum.map(&hd/1) |> Enum.map(&String.length/1) |> Enum.max()
+      formatted = Enum.map(table, fn [name, error] ->
+        String.pad_trailing(name, width + 3) <> error
+      end)
+
+      {:text, formatted}
+    else
+      {:ok, "No errors"}
+    end
+  end
+
+  defp extract_errors({:ok, result}, opts) do
+    if Keyword.get(opts.options, :errors_only, false) do
+      configs_with_error =
         Enum.filter(result["configs"], fn config ->
           Enum.any?(get_in(config, ["value", "errors"]))
         end)
 
-      {:ok, errors}
+      {:ok, configs_with_error}
     else
       {:ok, result}
     end

--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -373,7 +373,7 @@ defmodule Kconnectex.CLI do
   end
 
   defp read_stdin do
-    IO.read(:stdio, :all)
+    IO.read(:stdio, :eof)
     |> String.trim()
     |> Jason.decode()
   end

--- a/lib/kconnectex/cli/help.ex
+++ b/lib/kconnectex/cli/help.ex
@@ -80,12 +80,12 @@ defmodule Kconnectex.CLI.Help do
     plugins
       List plugins installed on Connect worker
 
-    plugin validate [--errors-only]
+    plugin validate [--json]
       Validate connector plugin configuration.
       ConfigFile is read from STDIN and assumed to be JSON.
 
-      --errors-only
-      Filters the configuration to only those with errors.
+      --json
+      Return full response as JSON
     """)
   end
 

--- a/lib/kconnectex/cli/options.ex
+++ b/lib/kconnectex/cli/options.ex
@@ -26,8 +26,6 @@ defmodule Kconnectex.CLI.Options do
       # connector restart
       only_failed: :boolean,
       include_tasks: :boolean,
-      # plugin list
-      errors_only: :boolean,
     ]
 
     {parsed, command, invalid} = OptionParser.parse(args, strict: global_flags ++ command_flags)
@@ -168,12 +166,6 @@ defmodule Kconnectex.CLI.Options do
     new_opts = invalid_flag_errors(opts, new_flags)
 
     %{new_opts | command: command, options: new_options}
-  end
-
-  defp with_command(opts, ["plugin", "validate"] = command, flags) do
-    errors_only = Keyword.get(flags, :errors_only, false)
-
-    %{opts | command: command, options: [errors_only: errors_only]}
   end
 
   defp with_command(opts, command, flags) do

--- a/test/kconnectex/cli/options_test.exs
+++ b/test/kconnectex/cli/options_test.exs
@@ -49,23 +49,6 @@ defmodule Kconnectex.CLI.OptionsTest do
       assert opts.command == ["cluster", "info"]
       assert opts.errors == []
     end
-
-    test "plugin validate --errors-only" do
-      opts = Options.parse(["--url", "example.com", "plugin", "validate", "--errors-only"])
-
-      assert {:errors_only, true} in opts.options
-      assert Enum.empty?(opts.errors)
-    end
-
-    test "--errors-only invalid for other commands" do
-      opts = Options.parse(["--url", "example.com", "plugin", "validate", "--errors-only"])
-
-      assert {:errors_only, true} in opts.options
-
-      opts = Options.parse(["--url", "example.com", "connectors", "--errors-only"])
-
-      assert "Unknown flag: --errors-only" in opts.errors
-    end
   end
 
   describe "connectors" do


### PR DESCRIPTION
Simplify output and incorporate the `kc-plugin-errors` script