### PR TITLE
Connector status watch

### DIFF
--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -1,5 +1,6 @@
 defmodule Kconnectex.CLI do
-  alias Kconnectex.CLI.{ConfigFile, Options}
+  alias Kconnectex.CLI.{ConfigFile, Options, Table}
+  alias Kconnectex.CLI.Watcher
 
   import Kconnectex.CLI.Help
 
@@ -230,6 +231,26 @@ defmodule Kconnectex.CLI do
     |> client()
     |> Kconnectex.Connectors.restart(connector, opts.options)
     |> display()
+  end
+
+  # --watch is always text
+  defp run(%{command: ["connector", "status", connector], url: url, watch?: true}) do
+    # prime the rendering, so we can render with headers
+    {:ok, status} = Kconnectex.Connectors.status(client(url), connector)
+    values = Kconnectex.CLI.Commands.Connectors.extract(status)
+    headers = Kconnectex.CLI.Commands.Connectors.headers()
+    table = Table.new(headers, values)
+    IO.puts(Table.render(table))
+
+    Watcher.start_link(
+      values: values,
+      call: fn -> Kconnectex.Connectors.status(client(url), connector) end,
+      transform: &Kconnectex.CLI.Commands.Connectors.extract/1,
+      render: &(Table.render_rows(table, &1))
+    )
+
+    # TODO: System.no_halt(true) not working here?
+    :timer.sleep(:infinity)
   end
 
   defp run(%{command: ["connector", "status", connector], url: url, format: :text}) do

--- a/lib/kconnectex/cli.ex
+++ b/lib/kconnectex/cli.ex
@@ -236,6 +236,7 @@ defmodule Kconnectex.CLI do
     case Kconnectex.Connectors.status(client(url), connector) do
       {:ok, status} ->
         status
+        |> Kconnectex.CLI.Commands.Connectors.extract()
         |> Kconnectex.CLI.Commands.Connectors.render()
         |> IO.puts()
 

--- a/lib/kconnectex/cli/commands/connectors.ex
+++ b/lib/kconnectex/cli/commands/connectors.ex
@@ -1,6 +1,4 @@
 defmodule Kconnectex.CLI.Commands.Connectors do
-  alias Kconnectex.Cli.Table
-
   def extract(status) do
     connector = [
       status["name"],

--- a/lib/kconnectex/cli/commands/connectors.ex
+++ b/lib/kconnectex/cli/commands/connectors.ex
@@ -10,6 +10,7 @@ defmodule Kconnectex.CLI.Commands.Connectors do
       status["connector"]["state"]
     ]
 
+    # TODO: rows should be sorted by id
     task_rows = Enum.flat_map(status["tasks"], fn task ->
       task_row = [status["name"], "TASK", to_string(task["id"]), task["worker_id"], task["state"]]
 
@@ -25,12 +26,7 @@ defmodule Kconnectex.CLI.Commands.Connectors do
     [connector | task_rows]
   end
 
-  def render(status_rows, _opts \\ []) do
-    Table.new(headers(), status_rows)
-    |> Table.render()
-  end
-
-  defp headers do
+  def headers do
     ["CONNECTOR", "TYPE", "ID", "WORKER_ID", "STATE"]
   end
 end

--- a/lib/kconnectex/cli/commands/connectors.ex
+++ b/lib/kconnectex/cli/commands/connectors.ex
@@ -10,18 +10,26 @@ defmodule Kconnectex.CLI.Commands.Connectors do
       status["connector"]["state"]
     ]
 
-    # TODO: rows should be sorted by id
-    task_rows = Enum.flat_map(status["tasks"], fn task ->
-      task_row = [status["name"], "TASK", to_string(task["id"]), task["worker_id"], task["state"]]
+    task_rows =
+      status["tasks"]
+      |> Enum.sort_by(fn task -> task["id"] end)
+      |> Enum.flat_map(fn task ->
+        task_row = [
+          status["name"],
+          "TASK",
+          to_string(task["id"]),
+          task["worker_id"],
+          task["state"]
+        ]
 
-      if Map.has_key?(task, "trace") do
-        trace = String.split(task["trace"], "\n")
+        if Map.has_key?(task, "trace") do
+          trace = String.split(task["trace"], "\n")
 
-        [task_row | [{:lines, trace}]]
-      else
-        [task_row]
-      end
-    end)
+          [task_row | [{:lines, trace}]]
+        else
+          [task_row]
+        end
+      end)
 
     [connector | task_rows]
   end

--- a/lib/kconnectex/cli/options.ex
+++ b/lib/kconnectex/cli/options.ex
@@ -163,6 +163,11 @@ defmodule Kconnectex.CLI.Options do
     end
   end
 
+  defp with_command(opts, command = ["connector", "status" | _], _flags) do
+    # watch? handled above
+     %{opts | command: command}
+  end
+
   defp with_command(opts, command = ["connector", "restart" | _], flags) do
     only_failed? = Keyword.get(flags, :only_failed, false)
     include_tasks? = Keyword.get(flags, :include_tasks, false)

--- a/lib/kconnectex/cli/options.ex
+++ b/lib/kconnectex/cli/options.ex
@@ -2,7 +2,16 @@ defmodule Kconnectex.CLI.Options do
   alias Kconnectex.CLI.ConfigFile
 
   @enforce_keys [:config]
-  defstruct [:config, url: :unset, help?: false, format: :text, command: [], options: [], errors: []]
+  defstruct [
+    :config,
+    url: :unset,
+    help?: false,
+    format: :text,
+    watch?: false,
+    command: [],
+    options: [],
+    errors: []
+  ]
 
   def extract(args) do
     case ConfigFile.read() do
@@ -24,6 +33,8 @@ defmodule Kconnectex.CLI.Options do
     command_flags = [
       # connectors
       expand: :string,
+      # connector status
+      watch: :boolean,
       # connector restart
       only_failed: :boolean,
       include_tasks: :boolean,
@@ -34,6 +45,7 @@ defmodule Kconnectex.CLI.Options do
     %__MODULE__{
       help?: Keyword.get(parsed, :help, false),
       format: if(Keyword.get(parsed, :json, false), do: :json, else: :text),
+      watch?: Keyword.get(parsed, :watch, false),
       config: config
     }
     |> with_command(command, extract_flags(parsed, command_flags))

--- a/lib/kconnectex/cli/options.ex
+++ b/lib/kconnectex/cli/options.ex
@@ -20,6 +20,7 @@ defmodule Kconnectex.CLI.Options do
 
   def parse(args, config \\ %{}) do
     global_flags = [cluster: :string, help: :boolean, url: :string, json: :boolean]
+
     command_flags = [
       # connectors
       expand: :string,
@@ -32,7 +33,7 @@ defmodule Kconnectex.CLI.Options do
 
     %__MODULE__{
       help?: Keyword.get(parsed, :help, false),
-      format: (if Keyword.get(parsed, :json, false), do: :json, else: :text),
+      format: if(Keyword.get(parsed, :json, false), do: :json, else: :text),
       config: config
     }
     |> with_command(command, extract_flags(parsed, command_flags))
@@ -155,8 +156,12 @@ defmodule Kconnectex.CLI.Options do
     include_tasks? = Keyword.get(flags, :include_tasks, false)
 
     new_options = opts.options
-    new_options = if only_failed?, do: Keyword.put(new_options, :only_failed, true), else: new_options
-    new_options = if include_tasks?, do: Keyword.put(new_options, :include_tasks, true), else: new_options
+
+    new_options =
+      if only_failed?, do: Keyword.put(new_options, :only_failed, true), else: new_options
+
+    new_options =
+      if include_tasks?, do: Keyword.put(new_options, :include_tasks, true), else: new_options
 
     new_flags =
       flags

--- a/lib/kconnectex/cli/table.ex
+++ b/lib/kconnectex/cli/table.ex
@@ -42,7 +42,7 @@ defmodule Kconnectex.Cli.Table do
       end)
       |> Enum.map(&String.trim/1)
 
-    Enum.join(lines, "\n") <> "\n"
+    Enum.join(lines, "\n")
   end
 
   defp max_column_widths(column_widths, rows) do

--- a/lib/kconnectex/cli/table.ex
+++ b/lib/kconnectex/cli/table.ex
@@ -1,4 +1,4 @@
-defmodule Kconnectex.Cli.Table do
+defmodule Kconnectex.CLI.Table do
   defstruct [:column_widths, :headers, :rows]
 
   @column_spacer "   "

--- a/lib/kconnectex/cli/table.ex
+++ b/lib/kconnectex/cli/table.ex
@@ -1,0 +1,68 @@
+defmodule Kconnectex.Cli.Table do
+  defstruct [:column_widths, :headers, :rows]
+
+  @column_spacer "   "
+
+  def new(headers, rows \\ []) do
+    column_widths =
+      max_column_widths(
+        List.duplicate(0, length(headers)),
+        [headers | rows]
+      )
+
+    %__MODULE__{
+      column_widths: column_widths,
+      headers: headers,
+      rows: rows
+    }
+  end
+
+  def render(table) do
+    render_rows(table, [table.headers | table.rows])
+  end
+
+  def render_rows(table, rows) do
+    lines =
+      rows
+      |> Enum.map(fn
+        {:lines, lines} ->
+          Enum.join(lines, "\n")
+
+        row ->
+          [row, table.column_widths]
+          |> Enum.zip()
+          |> Enum.map(fn {value, column_width} ->
+            if String.length(value) > column_width do
+              String.slice(value, 0, column_width - 3) <> "..."
+            else
+              String.pad_trailing(value, column_width)
+            end
+          end)
+          |> Enum.join(@column_spacer)
+      end)
+      |> Enum.map(&String.trim/1)
+
+    Enum.join(lines, "\n") <> "\n"
+  end
+
+  defp max_column_widths(column_widths, rows) do
+    rows
+    |> Enum.reject(&match?({:lines, _}, &1))
+    |> Enum.zip()
+    |> Enum.map(fn col_tuple ->
+      col_tuple
+      |> Tuple.to_list()
+      |> Enum.map(&value_length/1)
+      |> Enum.max()
+    end)
+    |> Enum.zip(column_widths)
+    |> Enum.map(&Tuple.to_list/1)
+    |> Enum.map(&Enum.max/1)
+  end
+
+  defp value_length(value) do
+    value
+    |> to_string()
+    |> String.length()
+  end
+end

--- a/lib/kconnectex/cli/watcher.ex
+++ b/lib/kconnectex/cli/watcher.ex
@@ -40,10 +40,9 @@ defmodule Kconnectex.CLI.Watcher do
   end
 
   # TODO: More specific error message
-  # TODO: same error appears to be seen as "new"
   defp diff(previous, {:error, reason}, _transformer) do
     case previous do
-      {:error, ^reason} ->
+      [{:error, ^reason}] ->
         {[{:error, reason}], []}
 
       _otherwise ->

--- a/lib/kconnectex/cli/watcher.ex
+++ b/lib/kconnectex/cli/watcher.ex
@@ -1,0 +1,73 @@
+defmodule Kconnectex.CLI.Watcher do
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  def init(opts) do
+    state = %{
+      # parameters
+      call: Keyword.fetch!(opts, :call),
+      transform: Keyword.fetch!(opts, :transform),
+      render: Keyword.fetch!(opts, :render),
+      previous_values: Keyword.get(opts, :values, []),
+      interval: Keyword.get(opts, :interval, 10_000)
+    }
+
+    {:ok, state, {:continue, :fetch}}
+  end
+
+  def handle_info(:fetch, state), do: handle_fetch(state)
+
+  def handle_continue(:fetch, state), do: handle_fetch(state)
+
+  defp handle_fetch(state) do
+    latest_values = state[:call].()
+
+    {new_previous_values, updates} =
+      diff(state[:previous_values], latest_values, state[:transform])
+
+    if Enum.any?(updates) do
+      state[:render].(updates) |> IO.puts()
+    end
+
+    new_state = %{state | previous_values: new_previous_values}
+
+    Process.send_after(self(), :fetch, state[:interval])
+
+    {:noreply, new_state}
+  end
+
+  # TODO: More specific error message
+  # TODO: same error appears to be seen as "new"
+  defp diff(previous, {:error, reason}, _transformer) do
+    case previous do
+      {:error, ^reason} ->
+        {[{:error, reason}], []}
+
+      _otherwise ->
+        {[{:error, reason}], [{:lines, ["Error: #{reason}"]}]}
+    end
+  end
+
+  defp diff([], {:ok, values}, transformer) do
+    current = transformer.(values)
+
+    {current, current}
+  end
+
+  defp diff({:error, _reason}, {:ok, values}, transformer) do
+    current = transformer.(values)
+
+    {current, current}
+  end
+
+  defp diff(previous, {:ok, values}, transformer) do
+    current = transformer.(values)
+
+    diff = MapSet.difference(MapSet.new(current), MapSet.new(previous))
+
+    {current, Enum.into(diff, [])}
+  end
+end

--- a/lib/kconnectex/connectors.ex
+++ b/lib/kconnectex/connectors.ex
@@ -26,7 +26,7 @@ defmodule Kconnectex.Connectors do
 
   {:ok, ["debezium", "replicator"]}
 
-  > Kconnectex.Connectors.list(client, :status)
+  > Kconnectex.Connectors.list(client, expand: :status)
 
   {:ok, %{
     "debezium" => %{
@@ -98,8 +98,6 @@ defmodule Kconnectex.Connectors do
   - connector: the connector name
 
   ## Options
-
-  - expand: either `:status`, `:info`, or a list of them: `[:info, :status]`
 
   - include_tasks (boolean, default: false): also restart the tasks
   - only_failed (boolean, default: false): only restart the connector (and optionally tasks) that are FAILED

--- a/lib/kconnectex/connectors.ex
+++ b/lib/kconnectex/connectors.ex
@@ -197,11 +197,13 @@ defmodule Kconnectex.Connectors do
 
   defp process_expand(opts) do
     expand = Keyword.get(opts, :expand, [])
-    expand = if is_atom(expand) do
-      [expand: expand]
-    else
-      Enum.map(expand, fn opt -> {:expand, opt} end)
-    end
+
+    expand =
+      if is_atom(expand) do
+        [expand: expand]
+      else
+        Enum.map(expand, fn opt -> {:expand, opt} end)
+      end
 
     new_opts = Keyword.delete(opts, :expand)
 

--- a/mix.exs
+++ b/mix.exs
@@ -30,8 +30,7 @@ defmodule Kconnectex.MixProject do
       {:hackney, "~> 1.21.0"},
       {:jason, ">= 1.0.0"},
       # https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27
-      {:ssl_verify_fun, ">= 0.0.0", manager: :rebar3, override: true},
-      {:table_rex, "~> 4.1"}
+      {:ssl_verify_fun, ">= 0.0.0", manager: :rebar3, override: true}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,8 @@ defmodule Kconnectex.MixProject do
       {:hackney, "~> 1.21.0"},
       {:jason, ">= 1.0.0"},
       # https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27
-      {:ssl_verify_fun, ">= 0.0.0", manager: :rebar3, override: true}
+      {:ssl_verify_fun, ">= 0.0.0", manager: :rebar3, override: true},
+      {:table_rex, "~> 4.1"}
     ]
   end
 

--- a/test/kconnectex/cli/commands/connectors_test.exs
+++ b/test/kconnectex/cli/commands/connectors_test.exs
@@ -1,4 +1,4 @@
-defmodule Kconnectex.Cli.Commands.ConnectorsTest do
+defmodule Kconnectex.CLI.Commands.ConnectorsTest do
   use ExUnit.Case, async: true
 
   alias Kconnectex.CLI.Commands.Connectors
@@ -8,9 +8,8 @@ defmodule Kconnectex.Cli.Commands.ConnectorsTest do
       status = connector("NAME", "RUNNING")
 
       assert render(status) == """
-              CONNECTOR   TYPE        ID   WORKER_ID   STATE
-
-              NAME        CONNECTOR        localhost   RUNNING
+             CONNECTOR   TYPE        ID   WORKER_ID   STATE
+             NAME        CONNECTOR        localhost   RUNNING
              """
     end
 
@@ -25,12 +24,11 @@ defmodule Kconnectex.Cli.Commands.ConnectorsTest do
         )
 
       assert render(status) == """
-              CONNECTOR   TYPE        ID   WORKER_ID   STATE
-
-              NAME        CONNECTOR        localhost   RUNNING
-              NAME        TASK        0    localhost   PAUSED
-              NAME        TASK        1    localhost   STOPPED
-              NAME        TASK        2    localhost   RUNNING
+             CONNECTOR   TYPE        ID   WORKER_ID   STATE
+             NAME        CONNECTOR        localhost   RUNNING
+             NAME        TASK        0    localhost   PAUSED
+             NAME        TASK        1    localhost   STOPPED
+             NAME        TASK        2    localhost   RUNNING
              """
     end
 
@@ -48,12 +46,14 @@ defmodule Kconnectex.Cli.Commands.ConnectorsTest do
         )
 
       assert render(status) == """
-              CONNECTOR   TYPE        ID   WORKER_ID   STATE
-
-              NAME        CONNECTOR        localhost   RUNNING
-              NAME        TASK        0    localhost   PAUSED
-              NAME        TASK        1    localhost   ERROR
-              NAME        TASK        2    localhost   RUNNING
+             CONNECTOR   TYPE        ID   WORKER_ID   STATE
+             NAME        CONNECTOR        localhost   RUNNING
+             NAME        TASK        0    localhost   PAUSED
+             NAME        TASK        1    localhost   ERROR
+             com.some.company.package.modules.BadException thrown by
+             line 12345...
+             line 123456...
+             NAME        TASK        2    localhost   RUNNING
              """
     end
 
@@ -83,10 +83,10 @@ defmodule Kconnectex.Cli.Commands.ConnectorsTest do
       }
 
       if Keyword.has_key?(opts, :trace) do
-        Map.put(t, :trace, Keyword.fetch!(opts, :trace))
+        Map.put(t, "trace", Keyword.fetch!(opts, :trace))
+      else
+        t
       end
-
-      t
     end
   end
 end

--- a/test/kconnectex/cli/commands/connectors_test.exs
+++ b/test/kconnectex/cli/commands/connectors_test.exs
@@ -1,66 +1,69 @@
 defmodule Kconnectex.CLI.Commands.ConnectorsTest do
   use ExUnit.Case, async: true
 
+  alias Kconnectex.CLI.Table
   alias Kconnectex.CLI.Commands.Connectors
+
+  import RenderAssertions
 
   describe "render/1" do
     test "shows connector name" do
-      status = connector("NAME", "RUNNING")
-
-      assert render(status) == """
-             CONNECTOR   TYPE        ID   WORKER_ID   STATE
-             NAME        CONNECTOR        localhost   RUNNING
-             """
+      connector("NAME", "RUNNING")
+      |> render()
+      |> assert_rendered("""
+      CONNECTOR   TYPE        ID   WORKER_ID   STATE
+      NAME        CONNECTOR        localhost   RUNNING
+      """)
     end
 
     test "shows tasks" do
-      status =
-        connector("NAME", "RUNNING",
-          tasks: [
-            task(0, "PAUSED"),
-            task(1, "STOPPED"),
-            task(2, "RUNNING")
-          ]
-        )
-
-      assert render(status) == """
-             CONNECTOR   TYPE        ID   WORKER_ID   STATE
-             NAME        CONNECTOR        localhost   RUNNING
-             NAME        TASK        0    localhost   PAUSED
-             NAME        TASK        1    localhost   STOPPED
-             NAME        TASK        2    localhost   RUNNING
-             """
+      connector("NAME", "RUNNING",
+        tasks: [
+          task(0, "PAUSED"),
+          task(1, "STOPPED"),
+          task(2, "RUNNING")
+        ]
+      )
+      |> render()
+      |> assert_rendered("""
+      CONNECTOR   TYPE        ID   WORKER_ID   STATE
+      NAME        CONNECTOR        localhost   RUNNING
+      NAME        TASK        0    localhost   PAUSED
+      NAME        TASK        1    localhost   STOPPED
+      NAME        TASK        2    localhost   RUNNING
+      """)
     end
 
     test "shows task stack traces" do
-      status =
-        connector("NAME", "RUNNING",
-          tasks: [
-            task(0, "PAUSED"),
-            task(1, "ERROR",
-              trace:
-                "com.some.company.package.modules.BadException thrown by\nline 12345...\nline 123456..."
-            ),
-            task(2, "RUNNING")
-          ]
-        )
-
-      assert render(status) == """
-             CONNECTOR   TYPE        ID   WORKER_ID   STATE
-             NAME        CONNECTOR        localhost   RUNNING
-             NAME        TASK        0    localhost   PAUSED
-             NAME        TASK        1    localhost   ERROR
-             com.some.company.package.modules.BadException thrown by
-             line 12345...
-             line 123456...
-             NAME        TASK        2    localhost   RUNNING
-             """
+      connector("NAME", "RUNNING",
+        tasks: [
+          task(0, "PAUSED"),
+          task(1, "ERROR",
+            trace:
+              "com.some.company.package.modules.BadException thrown by\nline 12345...\nline 123456..."
+          ),
+          task(2, "RUNNING")
+        ]
+      )
+      |> render()
+      |> assert_rendered("""
+      CONNECTOR   TYPE        ID   WORKER_ID   STATE
+      NAME        CONNECTOR        localhost   RUNNING
+      NAME        TASK        0    localhost   PAUSED
+      NAME        TASK        1    localhost   ERROR
+      com.some.company.package.modules.BadException thrown by
+      line 12345...
+      line 123456...
+      NAME        TASK        2    localhost   RUNNING
+      """)
     end
 
     defp render(status) do
-      status
-      |> Connectors.extract()
-      |> Connectors.render()
+      values = Connectors.extract(status)
+
+      Connectors.headers()
+      |> Table.new(values)
+      |> Table.render()
     end
 
     defp connector(name, state, opts \\ []) do

--- a/test/kconnectex/cli/commands/connectors_test.exs
+++ b/test/kconnectex/cli/commands/connectors_test.exs
@@ -5,71 +5,88 @@ defmodule Kconnectex.Cli.Commands.ConnectorsTest do
 
   describe "render/1" do
     test "shows connector name" do
-      status = %{
-        "name" => "NAME",
-        "connector" => %{"state" => "RUNNING"},
-        "tasks" => []
-      }
+      status = connector("NAME", "RUNNING")
 
-      assert Connectors.render(status) == """
-             NAME
-             ----
-             Connector: RUNNING
+      assert render(status) == """
+              CONNECTOR   TYPE        ID   WORKER_ID   STATE
+
+              NAME        CONNECTOR        localhost   RUNNING
              """
     end
 
     test "shows tasks" do
-      status = %{
-        "name" => "NAME",
-        "connector" => %{"state" => "RUNNING"},
-        "tasks" => [
-          %{"id" => "0", "state" => "PAUSED"},
-          %{"id" => "1", "state" => "STOPPED"},
-          %{"id" => "2", "state" => "RUNNING"}
-        ]
-      }
+      status =
+        connector("NAME", "RUNNING",
+          tasks: [
+            task(0, "PAUSED"),
+            task(1, "STOPPED"),
+            task(2, "RUNNING")
+          ]
+        )
 
-      assert Connectors.render(status) == """
-             NAME
-             ----
-             Connector: RUNNING
-             Task 0: PAUSED
-             Task 1: STOPPED
-             Task 2: RUNNING
+      assert render(status) == """
+              CONNECTOR   TYPE        ID   WORKER_ID   STATE
+
+              NAME        CONNECTOR        localhost   RUNNING
+              NAME        TASK        0    localhost   PAUSED
+              NAME        TASK        1    localhost   STOPPED
+              NAME        TASK        2    localhost   RUNNING
              """
     end
 
     test "shows task stack traces" do
-      status = %{
-        "name" => "NAME",
-        "connector" => %{"state" => "RUNNING"},
-        "tasks" => [
-          %{"id" => "0", "state" => "PAUSED"},
-          %{
-            "id" => "1",
-            "state" => "ERROR",
-            "trace" =>
-              "com.some.company.package.modules.BadException thrown by\nline 12345...\nline 123456..."
-          },
-          %{"id" => "2", "state" => "RUNNING"}
-        ]
-      }
+      status =
+        connector("NAME", "RUNNING",
+          tasks: [
+            task(0, "PAUSED"),
+            task(1, "ERROR",
+              trace:
+                "com.some.company.package.modules.BadException thrown by\nline 12345...\nline 123456..."
+            ),
+            task(2, "RUNNING")
+          ]
+        )
 
-      assert Connectors.render(status) == """
-             NAME
-             ----
-             Connector: RUNNING
-             Task 0: PAUSED
-             Task 1: ERROR
-             Trace:
-             com.some.company.package.modules.BadException thrown by
-             line 12345...
-             line 123456...
+      assert render(status) == """
+              CONNECTOR   TYPE        ID   WORKER_ID   STATE
 
-             Task 2: RUNNING
+              NAME        CONNECTOR        localhost   RUNNING
+              NAME        TASK        0    localhost   PAUSED
+              NAME        TASK        1    localhost   ERROR
+              NAME        TASK        2    localhost   RUNNING
              """
     end
 
-    # defp status(name, state, tasks \\ [])
+    defp render(status) do
+      status
+      |> Connectors.extract()
+      |> Connectors.render()
+    end
+
+    defp connector(name, state, opts \\ []) do
+      %{
+        "name" => name,
+        "connector" => %{
+          "state" => state,
+          "worker_id" => Keyword.get(opts, :worker_id, "localhost")
+        },
+        "tasks" => Keyword.get(opts, :tasks, []),
+        "type" => Keyword.get(opts, :type, "source")
+      }
+    end
+
+    defp task(id, state, opts \\ []) do
+      t = %{
+        "id" => id,
+        "state" => state,
+        "worker_id" => Keyword.get(opts, :worker_id, "localhost")
+      }
+
+      if Keyword.has_key?(opts, :trace) do
+        Map.put(t, :trace, Keyword.fetch!(opts, :trace))
+      end
+
+      t
+    end
   end
 end

--- a/test/kconnectex/cli/options_test.exs
+++ b/test/kconnectex/cli/options_test.exs
@@ -89,7 +89,15 @@ defmodule Kconnectex.CLI.OptionsTest do
     end
 
     test "connector restart :name --only-failed" do
-      opts = Options.parse(["--url", "example.com", "connector", "restart", "debezium", "--only-failed"])
+      opts =
+        Options.parse([
+          "--url",
+          "example.com",
+          "connector",
+          "restart",
+          "debezium",
+          "--only-failed"
+        ])
 
       assert Enum.empty?(opts.errors)
       assert opts.command == ["connector", "restart", "debezium"]
@@ -97,7 +105,15 @@ defmodule Kconnectex.CLI.OptionsTest do
     end
 
     test "connector restart :name --include-tasks" do
-      opts = Options.parse(["--url", "example.com", "connector", "restart", "debezium", "--include-tasks"])
+      opts =
+        Options.parse([
+          "--url",
+          "example.com",
+          "connector",
+          "restart",
+          "debezium",
+          "--include-tasks"
+        ])
 
       assert Enum.empty?(opts.errors)
       assert opts.command == ["connector", "restart", "debezium"]
@@ -105,7 +121,16 @@ defmodule Kconnectex.CLI.OptionsTest do
     end
 
     test "connector restart :name --only-failed --include-tasks" do
-      opts = Options.parse(["--url", "example.com", "connector", "restart", "debezium", "--include-tasks", "--only-failed"])
+      opts =
+        Options.parse([
+          "--url",
+          "example.com",
+          "connector",
+          "restart",
+          "debezium",
+          "--include-tasks",
+          "--only-failed"
+        ])
 
       assert Enum.empty?(opts.errors)
       assert opts.command == ["connector", "restart", "debezium"]

--- a/test/kconnectex/cli/options_test.exs
+++ b/test/kconnectex/cli/options_test.exs
@@ -49,6 +49,14 @@ defmodule Kconnectex.CLI.OptionsTest do
       assert opts.command == ["cluster", "info"]
       assert opts.errors == []
     end
+
+    test "--watch is false by default" do
+      refute Options.parse([]).watch?
+    end
+
+    test "--watch" do
+      assert Options.parse(["--watch"]).watch?
+    end
   end
 
   describe "connectors" do

--- a/test/kconnectex/cli/table_test.exs
+++ b/test/kconnectex/cli/table_test.exs
@@ -7,10 +7,12 @@ defmodule Kconnectex.CLI.TableTest do
     test "formats a table" do
       table = Table.new(["abc", "def"], [["1", "1001"]])
 
-      assert Table.render(table) == """
-             abc   def
-             1     1001
-             """
+      out = Table.render(table)
+
+      assert_rendered(out, """
+      abc   def
+      1     1001
+      """)
     end
 
     test "formats subsequeant rows correctly" do
@@ -19,11 +21,14 @@ defmodule Kconnectex.CLI.TableTest do
       first = Table.render(table)
       second = Table.render_rows(table, [["narrow", "<- whitespace"]])
 
-      assert first <> second == """
-             wide-column          narrow-column
-             longer-than-column   narrow
-             narrow               <- whitespace
-             """
+      assert_rendered(
+        [first, second],
+        """
+        wide-column          narrow-column
+        longer-than-column   narrow
+        narrow               <- whitespace
+        """
+      )
     end
 
     test "truncates columns that are subsequently longer" do
@@ -32,26 +37,38 @@ defmodule Kconnectex.CLI.TableTest do
       first = Table.render(table)
       second = Table.render_rows(table, [["a much wider column"]])
 
-      assert first <> second == """
-             column
-             a short column
-             a much wide...
-             """
+      assert_rendered([first, second], """
+      column
+      a short column
+      a much wide...
+      """)
     end
 
     test "renders lines" do
       table = Table.new(["state"], [["OK"]])
 
       first = Table.render(table)
-      second = Table.render_rows(table, [["ERROR"], {:lines, ["stacktrace line 1", "stacktrace line 2"]}])
 
-      assert first <> second == """
+      second =
+        Table.render_rows(table, [["ERROR"], {:lines, ["stacktrace line 1", "stacktrace line 2"]}])
+
+      assert_rendered([first, second], """
       state
       OK
       ERROR
       stacktrace line 1
       stacktrace line 2
-      """
+      """)
     end
+  end
+
+  def assert_rendered(parts, printed) when is_list(parts) do
+    assert concat(parts) == String.trim_trailing(printed, "\n")
+  end
+
+  def assert_rendered(part, printed), do: assert_rendered([part], printed)
+
+  defp concat(parts) do
+    Enum.join(parts, "\n")
   end
 end

--- a/test/kconnectex/cli/table_test.exs
+++ b/test/kconnectex/cli/table_test.exs
@@ -1,7 +1,7 @@
 defmodule Kconnectex.CLI.TableTest do
   use ExUnit.Case, async: true
 
-  alias Kconnectex.Cli.Table
+  alias Kconnectex.CLI.Table
 
   describe "print/2" do
     test "formats a table" do

--- a/test/kconnectex/cli/table_test.exs
+++ b/test/kconnectex/cli/table_test.exs
@@ -1,0 +1,57 @@
+defmodule Kconnectex.CLI.TableTest do
+  use ExUnit.Case, async: true
+
+  alias Kconnectex.Cli.Table
+
+  describe "print/2" do
+    test "formats a table" do
+      table = Table.new(["abc", "def"], [["1", "1001"]])
+
+      assert Table.render(table) == """
+             abc   def
+             1     1001
+             """
+    end
+
+    test "formats subsequeant rows correctly" do
+      table = Table.new(["wide-column", "narrow-column"], [["longer-than-column", "narrow"]])
+
+      first = Table.render(table)
+      second = Table.render_rows(table, [["narrow", "<- whitespace"]])
+
+      assert first <> second == """
+             wide-column          narrow-column
+             longer-than-column   narrow
+             narrow               <- whitespace
+             """
+    end
+
+    test "truncates columns that are subsequently longer" do
+      table = Table.new(["column"], [["a short column"]])
+
+      first = Table.render(table)
+      second = Table.render_rows(table, [["a much wider column"]])
+
+      assert first <> second == """
+             column
+             a short column
+             a much wide...
+             """
+    end
+
+    test "renders lines" do
+      table = Table.new(["state"], [["OK"]])
+
+      first = Table.render(table)
+      second = Table.render_rows(table, [["ERROR"], {:lines, ["stacktrace line 1", "stacktrace line 2"]}])
+
+      assert first <> second == """
+      state
+      OK
+      ERROR
+      stacktrace line 1
+      stacktrace line 2
+      """
+    end
+  end
+end

--- a/test/kconnectex/cli/table_test.exs
+++ b/test/kconnectex/cli/table_test.exs
@@ -3,6 +3,8 @@ defmodule Kconnectex.CLI.TableTest do
 
   alias Kconnectex.CLI.Table
 
+  import RenderAssertions
+
   describe "print/2" do
     test "formats a table" do
       table = Table.new(["abc", "def"], [["1", "1001"]])
@@ -60,15 +62,5 @@ defmodule Kconnectex.CLI.TableTest do
       stacktrace line 2
       """)
     end
-  end
-
-  def assert_rendered(parts, printed) when is_list(parts) do
-    assert concat(parts) == String.trim_trailing(printed, "\n")
-  end
-
-  def assert_rendered(part, printed), do: assert_rendered([part], printed)
-
-  defp concat(parts) do
-    Enum.join(parts, "\n")
   end
 end

--- a/test/kconnectex/cluster_test.exs
+++ b/test/kconnectex/cluster_test.exs
@@ -32,7 +32,7 @@ defmodule Kconnectex.ClusterTest do
     import IntegrationHelpers
 
     assert Cluster.health(Kconnectex.client("http://0.0.0.0:9999")) ==
-    {:error, :econnrefused}
+             {:error, :econnrefused}
 
     {:ok, health} = Cluster.health(connect_client())
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -22,5 +22,15 @@ defmodule Fixtures do
   end
 end
 
+defmodule RenderAssertions do
+  defmacro assert_rendered(part_or_parts, printed) do
+    parts = if is_list(part_or_parts), do: part_or_parts, else: [part_or_parts]
+
+    quote do
+      assert Enum.join(unquote(parts), "\n") == String.trim_trailing(unquote(printed), "\n")
+    end
+  end
+end
+
 ExUnit.configure(exclude: :integration)
 ExUnit.start()


### PR DESCRIPTION
Add a `--watch` option to `connector status`.

It's a bit messy but I want to add more watchers to see what state management makes sense.